### PR TITLE
Fixed Copy errors because of existing files.

### DIFF
--- a/windows.py
+++ b/windows.py
@@ -104,25 +104,32 @@ def main():
         cls()
         print(f"{Fore.CYAN}Converting. Please wait.\n[{str(a)}/{str(maxConvAmt)}]{Style.RESET_ALL}")
 
-    convertRem(0)
-    files_to_copy = {
-        "1": "dependancies\\process\\adafruit-circuitpython-raspberry_pi_pico-en_US-9.2.1.uf2",
-        "2": "dependancies\\process\\adafruit-circuitpython-raspberry_pi_pico_w-en_US-9.2.1.uf2",
-        "3": "dependancies\\process\\adafruit-circuitpython-raspberry_pi_pico2-en_US-9.2.1.uf2",
-        "4": "dependancies\\process\\adafruit-circuitpython-raspberry_pi_pico2_w-en_US-9.2.1.uf2",
-    }
-    shutil.copy(f"{files_to_copy[modelSelection]}",f"{selectedDriveLabel}:\\")
-    time.sleep(10)
-    convertRem(1)
-    shutil.copytree(f"dependancies\\final\\lib", f"{selectedDriveLabel}:\\lib")
-    convertRem(2)
-    shutil.copy(f"dependancies\\final\\boot.py", f"{selectedDriveLabel}:\\")
-    convertRem(3)
-    shutil.copy(f"dependancies\\final\\code.py", f"{selectedDriveLabel}:\\")
-    convertRem(4)
-    shutil.copy(f"dependancies\\final\\duckyinpython.py", f"{selectedDriveLabel}:\\")
-    convertRem(5)
-    shutil.copy(f"dependancies\\final\\payload.dd", f"{selectedDriveLabel}:\\")
+    try:
+        convertRem(0)
+        files_to_copy = {
+            "1": "dependancies\\process\\adafruit-circuitpython-raspberry_pi_pico-en_US-9.2.1.uf2",
+            "2": "dependancies\\process\\adafruit-circuitpython-raspberry_pi_pico_w-en_US-9.2.1.uf2",
+            "3": "dependancies\\process\\adafruit-circuitpython-raspberry_pi_pico2-en_US-9.2.1.uf2",
+            "4": "dependancies\\process\\adafruit-circuitpython-raspberry_pi_pico2_w-en_US-9.2.1.uf2",
+        }
+        shutil.copy(f"{files_to_copy[modelSelection]}",f"{selectedDriveLabel}:\\")
+        time.sleep(10)
+        convertRem(1)
+        shutil.copytree(f"dependancies\\final\\lib", f"{selectedDriveLabel}:\\lib", dirs_exist_ok=True)
+        convertRem(2)
+        shutil.copy(f"dependancies\\final\\boot.py", f"{selectedDriveLabel}:\\")
+        convertRem(3)
+        shutil.copy(f"dependancies\\final\\code.py", f"{selectedDriveLabel}:\\")
+        convertRem(4)
+        shutil.copy(f"dependancies\\final\\duckyinpython.py", f"{selectedDriveLabel}:\\")
+        convertRem(5)
+        shutil.copy(f"dependancies\\final\\payload.dd", f"{selectedDriveLabel}:\\")
+    except Exception as e:
+        cls()
+        print(f"{Fore.RED}Error during conversion: {str(e)}{Style.RESET_ALL}")
+        print(f"{Fore.YELLOW}This might happen if files already exist or the drive is not accessible.{Style.RESET_ALL}")
+        input("\nPress [ENTER] to exit.")
+        sys.exit(1)
 
     # FINISH
     cls()


### PR DESCRIPTION
(Copilot)
This pull request improves the robustness of the `convertRem` function in `windows.py` by adding error handling and updating a directory copy operation to avoid failures when the destination already exists.

**Error handling improvements:**

* Wrapped the main logic of `convertRem` in a `try`/`except` block to catch and display errors during the conversion process, providing a user-friendly error message and clean exit if something goes wrong. [[1]](diffhunk://#diff-436c409f466a07ccb6b857d6cc32464181aec39d8f36fd64d77685aa67cfc898R107) [[2]](diffhunk://#diff-436c409f466a07ccb6b857d6cc32464181aec39d8f36fd64d77685aa67cfc898R127-R132)

**File operation enhancements:**

* Updated the `shutil.copytree` call to use `dirs_exist_ok=True`, allowing the copy to succeed even if the target directory already exists, which helps prevent errors during repeated operations.
(Copilot end)
Resolved an issue preventing the tool from executing by implementing a fix for a newly identified runtime error.